### PR TITLE
I4 chickadee cancel integration

### DIFF
--- a/on-demand_downscaling/README.md
+++ b/on-demand_downscaling/README.md
@@ -8,20 +8,23 @@ To restart the notebook, click on <b>Kernel&rarr;Restart Kernel</b> at the top l
 
 The workflow takes advantage of applications used in the DACCS project called "birds", which convert packages into web services. The notebook is split into two major sections.
 
+### _Please note that all output files will be removed from PCIC servers after a period of two days. We encourage you to download any data you may need within this timeframe._
+
 ## 1. Downscaling GCM Data
 
 This step consists of downscaling a 3x3 degree low-resolution subset of a GCM dataset to a 2.5x2.5 degree high-resolution subset (the larger input subdomain ensures that the target grid is entirely contained within the input grid). It achieves this by using PCIC's [chickadee](https://github.com/pacificclimate/chickadee) service, which is based on the [ClimDown](https://github.com/pacificclimate/climdown) package, to run a process called [Climate Imprint](https://github.com/pacificclimate/ClimDown/blob/master/R/CI.R). The target grid used here is the one for the 1981-2010 BC PRISM climatologies.
 
 In order to easily provide inputs to the service, the notebook contains an interactive map with various widgets. The inputs are as follows:
+
 - The <b>center point</b> of the subdomains of the GCM/target regions
 - The <b>region name</b> describing the chosen subregions
 - The <b>climate variable</b> from the GCM input to downscale
 - The <b>dataset</b> to use as the GCM input. Currently, you can choose between the daily PNWNAmet observations or the CMIP6 data. If you choose the CMIP6 data, you can further specify the following:
-   - The <b>downscaling technique</b> originally used to downscale (either BCCAQv2 or MBCn)
-   - The <b>climate model</b>
-   - The <b>CanESM5 run</b> if CanESM5 is the selected model
-   - The <b>emissions scenario</b>
-   - The <b>downscaled period</b> dictating the time range to downscale the input data
+  - The <b>downscaling technique</b> originally used to downscale (either BCCAQv2 or MBCn)
+  - The <b>climate model</b>
+  - The <b>CanESM5 run</b> if CanESM5 is the selected model
+  - The <b>emissions scenario</b>
+  - The <b>downscaled period</b> dictating the time range to downscale the input data
 
 After you specify your inputs, you can click on the `Run Downscaling` button to begin said process. You can even adjust your inputs and click on the button again to start multiple processes. These processes can be tracked with progress bars that appear below the map with approximate times to completion. Once your processes are completed, you can then check that they have finished without problems and download them if you wish.
 
@@ -29,29 +32,29 @@ After you specify your inputs, you can click on the `Run Downscaling` button to 
 
 After obtaining high-resolution data in step 1, you can compute climate indices from the results. These indices are computed using Ouranos's [finch](https://github.com/bird-house/finch/tree/master) service, which is based on their [xclim](https://github.com/Ouranosinc/xclim/tree/main) package. From the output files in step 1, you can filter which ones are used for obtaining indices, and the ones corresponding to the relevant climate variables will be enabled. Currently, a subset of the [core climdex indices](https://climate-scenarios.canada.ca/?page=climdex-indices) and degree days can be calculated with more to be available in the future. In appropriate cases, you can specify the threshold value and time resolution. The table below summarizes the available indices (refer to the climdex indices page for more details):
 
-| Variable | Climdex Index Name | Index Name in Notebook | Threshold Value | Finch Process | 
-| -------- | ------------------ | ---------------------- | ------------- | ------------- |
-| pr | Rxnday | Max N-day Precip Amount | 1 day | max_n_day_precipitation_amount |
-| | Simple Precipitation Intensity Index | Simple Precip Intensity Index | 1 mm/day | sdii |
-| | Rnnmm | Days with Precip over Threshold of N-mm | 1 mm/day | wetdays |
-| | Maximum Length of Dry Spell | Maximum Length of Dry Spell | 1 mm/day | cdd |
-| | Maximum Length of Wet Spell | Maximum Length of Wet Spell | 1 mm/day | cwd |
-| | PRCPTOT | Total Wet-Day Precip | 1 mm/day | wet_prcptot |
-| tasmax | Summer Days | Summer Days | 25 degC | tx_days_above |
-| | Ice Days | Ice Days | 0 degC | ice_days |
-| | TXx | Hottest Day | NA | tx_max |
-| | TXn | Coldest Day | NA | tx_min |
-| tasmin | Frost Days | Frost Days | 0 degC | frost_days |
-| | Tropical Nights | Tropical Nights | 20 degC | tropical_nights |
-| | TNx | Hottest Night | NA | tn_max |
-| | TNn | Coldest Night | NA | tn_min |
-| tasmean | Growing Season Length | Growing Season Length | 5 degC | growing_season_length |
-| | Cooling Degree Days | Cooling Degree Days | 18 degC | cooling_degree_days |
-| | Freezing Degree Days | Freezing Degree Days | 0 degC | freezing_degree_days |
-| | Growing Degree Days | Growing Degree Days | 5 degC | growing_degree_days |
-| | Heating Degree Days | Heating Degree Days | 18 degC | heating_degree_days |
-| tasmin+tasmax | Daily Temperature Range | Daily Temperature Range | NA | dtr |
-| | Freeze-Thaw Days | Freeze-Thaw Days | 0 degC | freezethaw_spell_frequency |
+| Variable      | Climdex Index Name                   | Index Name in Notebook                  | Threshold Value | Finch Process                  |
+| ------------- | ------------------------------------ | --------------------------------------- | --------------- | ------------------------------ |
+| pr            | Rxnday                               | Max N-day Precip Amount                 | 1 day           | max_n_day_precipitation_amount |
+|               | Simple Precipitation Intensity Index | Simple Precip Intensity Index           | 1 mm/day        | sdii                           |
+|               | Rnnmm                                | Days with Precip over Threshold of N-mm | 1 mm/day        | wetdays                        |
+|               | Maximum Length of Dry Spell          | Maximum Length of Dry Spell             | 1 mm/day        | cdd                            |
+|               | Maximum Length of Wet Spell          | Maximum Length of Wet Spell             | 1 mm/day        | cwd                            |
+|               | PRCPTOT                              | Total Wet-Day Precip                    | 1 mm/day        | wet_prcptot                    |
+| tasmax        | Summer Days                          | Summer Days                             | 25 degC         | tx_days_above                  |
+|               | Ice Days                             | Ice Days                                | 0 degC          | ice_days                       |
+|               | TXx                                  | Hottest Day                             | NA              | tx_max                         |
+|               | TXn                                  | Coldest Day                             | NA              | tx_min                         |
+| tasmin        | Frost Days                           | Frost Days                              | 0 degC          | frost_days                     |
+|               | Tropical Nights                      | Tropical Nights                         | 20 degC         | tropical_nights                |
+|               | TNx                                  | Hottest Night                           | NA              | tn_max                         |
+|               | TNn                                  | Coldest Night                           | NA              | tn_min                         |
+| tasmean       | Growing Season Length                | Growing Season Length                   | 5 degC          | growing_season_length          |
+|               | Cooling Degree Days                  | Cooling Degree Days                     | 18 degC         | cooling_degree_days            |
+|               | Freezing Degree Days                 | Freezing Degree Days                    | 0 degC          | freezing_degree_days           |
+|               | Growing Degree Days                  | Growing Degree Days                     | 5 degC          | growing_degree_days            |
+|               | Heating Degree Days                  | Heating Degree Days                     | 18 degC         | heating_degree_days            |
+| tasmin+tasmax | Daily Temperature Range              | Daily Temperature Range                 | NA              | dtr                            |
+|               | Freeze-Thaw Days                     | Freeze-Thaw Days                        | 0 degC          | freezethaw_spell_frequency     |
 
 After you specify which indices you want to compute, you can click on the `Calculate Indices` button to begin those processes. As for step 1, you can track them with progress bars that appear below the list, though approximate completion times are not available for all indices as they have not been tested extensively. From initial testing on the PNWNAmet data, we have found that the `Hottest Day` and `Coldest Night` indices take ~45 minutes, `Days with Precip over Threshold of N-mm` takes ~50 minutes, and `Growing Season Length` takes ~30 minutes. Also, as for step 1, you can check that the processes have completed successfully and download the output files.
 
@@ -60,16 +63,21 @@ Please note that for indices requiring multiple variables, you can only compute 
 ## Additional Information
 
 #### `ERROR` Messages Below Progress Bars
+
 Sometimes when a downscaling or index computation process is running, you might see a message that says `ERROR:root:Could not read status document.` or `ERROR:root:Could not parse XML response.`. From testing, the processes have always successfully completed even with these messages, so they can be safely ignored.
 
 #### `tasmean` Calculations
+
 Since daily `tasmean` data is unavailable by default, it is first calculated in step 1 by obtaining `tasmax` and `tasmin` subsets from the specified inputs, then passing them to `finch` to calculate low-resolution `tasmean` data. Afterwards, it is passed to `chickadee` to calculate high-resolution data as normal. The initial low-resolution `tasmean` calculation takes ~2 minutes for the PNWNAmet data, and while it is happening, you cannot run other cells, so it would be best to start these processes after the ones for other variables.
 
 #### Preserving Outputs
+
 The downscaled outputs from step 1 are quite large (~9 GB for PNWNAmet, ~7.5 GB for CMIP6 during the 1950-2010 historical period, and ~15 GB for CMIP6 during the 1981-2100 calibration+future period). Until we determine a location where we can store many of these outputs, we would prefer to not keep them around for long. As such, if you would like to preserve these outputs for later use, it is recommended that you download them using the URLs. Also note that restarting the notebook will not save the output URLs, so make a copy of their locations if you would like to access them later.
 
 #### Calculating Indices from Downscaled Outputs from Previous Sessions
+
 If you have saved the URL of a downscaled output that was created during a previous session, you can use this URL in the cell marked `add_previous_downscaled_output` in step VI. This will add it to the list of output files that can be used for computing indices. However, since we're currently storing these outputs in the short term, it is possible that it has been removed from our storage. In this case, you will have to recompute it in step 1 and save the new URL.
 
 #### `helpers.py` Module
+
 The notebook makes use of several helper functions and objects from the `helpers.py` module. While you do not need to look at it to understand how to use the notebook, interested readers and those with previous Python experience can do so to see the finer details on how the notebook is set up.

--- a/on-demand_downscaling/helpers.py
+++ b/on-demand_downscaling/helpers.py
@@ -372,16 +372,16 @@ def handle_run_downscaling(arg):
             chickadee_params["pr_units"] = "mm/day"
     if dataset_name == "PNWNAmet":
         chickadee_params["out_file"] = (
-            f"{gcm_var}_{dataset_name}_1945-2012_{region_name}_on-demand.nc"
+            f"{gcm_var}_{dataset_name}_1945-2012_{region_name}.nc"
         )
     else:
         if not canesm5_run.disabled:
             chickadee_params["out_file"] = (
-                f"{gcm_var}_{dataset_name}_{technique.value}_{model.value}_{canesm5_run.value}_{scenario.value}_{period.value}_{region_name}_on-demand.nc"
+                f"{gcm_var}_{dataset_name}_{technique.value}_{model.value}_{canesm5_run.value}_{scenario.value}_{period.value}_{region_name}.nc"
             )
         else:
             chickadee_params["out_file"] = (
-                f"{gcm_var}_{dataset_name}_{technique.value}_{model.value}_{scenario.value}_{period.value}_{region_name}_on-demand.nc"
+                f"{gcm_var}_{dataset_name}_{technique.value}_{model.value}_{scenario.value}_{period.value}_{region_name}.nc"
             )
 
     print(f"Downscaling subset of {gcm_file.split('/')[-1]}")
@@ -450,7 +450,6 @@ def handle_run_downscaling(arg):
                 run_downscaling.tooltip = button_original_state["tooltip"]
 
             def custom_cancel(b):
-                """Custom cancel handler"""
                 global cooldown_timer, run_downscaling, button_original_state
 
                 print(f"Cancelling process UUID: {process_uuid}")

--- a/on-demand_downscaling/helpers.py
+++ b/on-demand_downscaling/helpers.py
@@ -400,8 +400,6 @@ def handle_run_downscaling(arg):
         status_url = ci_process.statusLocation
         process_uuid = urlparse(status_url).path.split("/")[-1].replace(".xml", "")
         print(f"Downscaling process UUID: {process_uuid}")
-
-        # Get widget reference
         birdy_widget = captured.outputs[0].data[
             "application/vnd.jupyter.widget-view+json"
         ]["model_id"]
@@ -432,7 +430,7 @@ def handle_run_downscaling(arg):
 
             def status_checker():
                 while check_process_status():
-                    sleep(5)
+                    sleep(1)
 
             # Start status checking in a separate thread
             Thread(target=status_checker, daemon=True).start()
@@ -479,7 +477,7 @@ def handle_run_downscaling(arg):
                 run_downscaling.style.button_color = "lightgray"
                 run_downscaling.description = "Please Wait"
                 run_downscaling.tooltip = (
-                    "Cooldown period after cancellation (30 seconds)"
+                    "Cooldown period after cancellation (45 seconds)"
                 )
                 print("Run Downscaling button disabled - cooldown started")
 
@@ -489,10 +487,10 @@ def handle_run_downscaling(arg):
                     print("Existing timer cancelled")
 
                 # Start a new timer
-                cooldown_timer = Timer(30.0, restore_button)
+                cooldown_timer = Timer(45.0, restore_button)
                 cooldown_timer.daemon = True
                 cooldown_timer.start()
-                print(f"New 30-second timer started")
+                print(f"New 45-second timer started")
 
                 # Execute all original handlers
                 for handler in original_handlers:

--- a/on-demand_downscaling/helpers.py
+++ b/on-demand_downscaling/helpers.py
@@ -1,11 +1,13 @@
 import os
 import numpy as np
+import requests
 from birdy import WPSClient
 from netCDF4 import Dataset, date2num
 from inspect import getfullargspec
 from datetime import date
 from datetime import datetime
 from time import sleep
+from threading import Thread, Timer
 from requests_html import HTMLSession
 from ipywidgets import *
 from ipyleaflet import *
@@ -13,10 +15,12 @@ from IPython import display as ipydisplay
 from xarray import open_mfdataset
 from tempfile import NamedTemporaryFile
 from functools import partial
+from urllib.parse import urlparse
+from IPython.utils.capture import capture_output
 
 # Instantiate the clients to the two birds. This instantiation also takes advantage of asynchronous execution by setting `progress` to True.
 host = os.getenv("BIRDHOUSE_HOST_URL", "https://marble-dev01.pcic.uvic.ca")
-chickadee_url = f"{host.replace('https', 'http')}:30102" # Dev version of chickadee
+chickadee_url = f"{host.replace('https', 'http')}:30102"  # Dev version of chickadee
 chickadee = WPSClient(chickadee_url, progress=True)
 finch_url = f"{host}/twitcher/ows/proxy/finch/wps"
 finch = WPSClient(finch_url, progress=True)
@@ -210,6 +214,32 @@ def concat_baseline_future(gcm_dataset, gcm_subset_file, gcm_time_range):
     return gcm_subset_file
 
 
+def find_cancel_button(widget):
+    """
+    Recursively finds a button with the description 'Cancel' in a widget hierarchy.
+    Returns:
+        ipywidgets.Button or None: The first matching button found, or None.
+    """
+    if isinstance(widget, Button) and widget.description.lower() == "cancel":
+        return widget
+    if hasattr(widget, "children"):
+        for child in widget.children:
+            found = find_cancel_button(child)
+            if found:
+                return found
+    return None
+
+
+button_original_state = {
+    "disabled": False,
+    "color": None,
+    "description": None,
+    "tooltip": None,
+}
+
+cooldown_timer = None
+
+
 @output_widget_downscaling.capture()
 def handle_run_downscaling(arg):
     """If all inputs to the interactive map have been provided,
@@ -341,18 +371,18 @@ def handle_run_downscaling(arg):
         if gcm_var == "pr":
             chickadee_params["pr_units"] = "mm/day"
     if dataset_name == "PNWNAmet":
-        chickadee_params[
-            "out_file"
-        ] = f"{gcm_var}_{dataset_name}_1945-2012_{region_name}_on-demand.nc"
+        chickadee_params["out_file"] = (
+            f"{gcm_var}_{dataset_name}_1945-2012_{region_name}_on-demand.nc"
+        )
     else:
         if not canesm5_run.disabled:
-            chickadee_params[
-                "out_file"
-            ] = f"{gcm_var}_{dataset_name}_{technique.value}_{model.value}_{canesm5_run.value}_{scenario.value}_{period.value}_{region_name}_on-demand.nc"
+            chickadee_params["out_file"] = (
+                f"{gcm_var}_{dataset_name}_{technique.value}_{model.value}_{canesm5_run.value}_{scenario.value}_{period.value}_{region_name}_on-demand.nc"
+            )
         else:
-            chickadee_params[
-                "out_file"
-            ] = f"{gcm_var}_{dataset_name}_{technique.value}_{model.value}_{scenario.value}_{period.value}_{region_name}_on-demand.nc"
+            chickadee_params["out_file"] = (
+                f"{gcm_var}_{dataset_name}_{technique.value}_{model.value}_{scenario.value}_{period.value}_{region_name}_on-demand.nc"
+            )
 
     print(f"Downscaling subset of {gcm_file.split('/')[-1]}")
     print(f"Creating {chickadee_params['out_file']}")
@@ -361,9 +391,144 @@ def handle_run_downscaling(arg):
     else:
         approx_time = 12 if period.value == "1950-2010" else 24
     print(f"Approximate time to completion: {str(approx_time)} minutes")
-    global downscaled_outputs
-    downscaled_outputs[gcm_var].append(chickadee.ci(**chickadee_params))
-    print()
+
+    try:
+        with capture_output() as captured:
+            ci_process = chickadee.ci(**chickadee_params)
+
+        # Retrieve the UUID
+        status_url = ci_process.statusLocation
+        process_uuid = urlparse(status_url).path.split("/")[-1].replace(".xml", "")
+        print(f"Downscaling process UUID: {process_uuid}")
+        birdy_widget = captured.outputs[0].data[
+            "application/vnd.jupyter.widget-view+json"
+        ]["model_id"]
+        widget_instance = Widget.widgets[birdy_widget]
+        cancel_button = find_cancel_button(widget_instance)
+
+        if cancel_button:
+            # Initially hide the cancel button until we confirm the process is running
+            cancel_button.layout.display = "none"
+
+            # Function to check if process is running and show the cancel button
+            def check_process_status():
+                try:
+                    # Get current status
+                    status_response = requests.get(status_url)
+                    if status_response.status_code == 200:
+                        status_text = status_response.text
+                        # Check if process is running (not queued)
+                        if "ProcessStarted" in status_text:
+                            # Process is running, show the cancel button
+                            cancel_button.layout.display = "block"
+                            return False  # Stop checking
+                        elif (
+                            "ProcessSucceeded" in status_text
+                            or "ProcessFailed" in status_text
+                        ):
+                            # Process completed or failed, no need to show cancel button
+                            return False  # Stop checking
+                    return True  # Continue checking
+                except Exception as e:
+                    print(f"Error checking process status: {e}")
+                    return False  # Stop checking on error
+
+            def status_checker():
+                while check_process_status():
+                    sleep(5)  # Check every 5 seconds
+
+            # Start status checking in a separate thread
+            Thread(target=status_checker, daemon=True).start()
+
+            # Save the original handlers before clearing them
+            original_handlers = list(cancel_button._click_handlers.callbacks)
+
+            # Clear existing handlers
+            cancel_button._click_handlers.callbacks.clear()
+
+            def restore_button():
+                """Function to restore the button to its original state"""
+                global run_downscaling, button_original_state
+                run_downscaling.disabled = button_original_state["disabled"]
+                run_downscaling.style.button_color = button_original_state["color"]
+                run_downscaling.description = button_original_state["description"]
+                run_downscaling.tooltip = button_original_state["tooltip"]
+
+            def custom_cancel(b):
+                """Custom cancel handler"""
+                global cooldown_timer, run_downscaling, button_original_state
+
+                # Cancel process
+                print(f"Cancelling process UUID: {process_uuid}")
+                try:
+                    url = f"{chickadee_url}/wps/cancel-process"
+                    resp = requests.post(url, json={"uuid": process_uuid})
+                    if resp.status_code == 200:
+                        print(resp.json()["message"])
+                    else:
+                        print(
+                            f"Failed to cancel. Status {resp.status_code}: {resp.text}"
+                        )
+                except Exception as e:
+                    print(f"Error calling cancel_process: {e}")
+
+                # Save original button state if this is the first time
+                if button_original_state["description"] is None:
+                    button_original_state["color"] = run_downscaling.style.button_color
+                    button_original_state["description"] = run_downscaling.description
+                    button_original_state["tooltip"] = run_downscaling.tooltip
+
+                # Disable the Run Downscaling button
+                run_downscaling.disabled = True
+                run_downscaling.style.button_color = "lightgray"
+                run_downscaling.description = "Please Wait"
+                run_downscaling.tooltip = (
+                    "Cooldown period after cancellation (30 seconds)"
+                )
+                print("Run Downscaling button disabled - cooldown started")
+
+                # Cancel any existing timer
+                if cooldown_timer is not None and cooldown_timer.is_alive():
+                    cooldown_timer.cancel()
+                    print("Existing timer cancelled")
+
+                # Start a new timer
+                cooldown_timer = Timer(30.0, restore_button)
+                cooldown_timer.daemon = True
+                cooldown_timer.start()
+                print(f"New 30-second timer started")
+
+                # Execute all original handlers
+                for handler in original_handlers:
+                    try:
+                        handler(b)
+                    except Exception as e:
+                        print(f"Error with original handler: {str(e)}")
+
+            # Attach the new handler
+            cancel_button.on_click(custom_cancel)
+
+            # Display captured Birdy widget
+            ipydisplay.display(widget_instance)
+            global downscaled_outputs
+            downscaled_outputs[gcm_var].append(ci_process)
+            print()
+    except Exception as e:
+        error_message = str(e)
+        if (
+            "ServerBusy" in error_message
+            and "Maximum number of processes in queue reached" in error_message
+        ):
+            print("\n⚠️ SERVER BUSY")
+            print(
+                "The processing queue is currently full. Your job cannot be submitted at this time."
+            )
+            print("Please wait for jobs to complete and try again")
+        else:
+            print(f"\n⚠️ ERROR: An unexpected error occurred during downscaling:")
+            print(f"{str(e)}")
+            print("Please check your inputs and try again.")
+        print()
 
 
 def get_output(resp):
@@ -554,7 +719,25 @@ def compute_indices(downscaled_outputs_thredds, indices, checkboxes):
                 f"Computing {box.children[0].description} from {(' and ').join(downscaled_outputs_filenames)}."
             )
             print(f"Creating {params['output_name']}.nc")
-            index_output = process(*downscaled_outputs_thredds, **params)
+            with capture_output() as captured:
+                index_output = process(*downscaled_outputs_thredds, **params)
+
+            try:
+                birdy_widget = captured.outputs[0].data[
+                    "application/vnd.jupyter.widget-view+json"
+                ]["model_id"]
+                widget_instance = Widget.widgets[birdy_widget]
+
+                cancel_button = find_cancel_button(widget_instance)
+
+                if cancel_button:
+                    cancel_button.layout.display = "none"
+                # Display progress bar without cancel option
+                ipydisplay.display(widget_instance)
+            except (KeyError, IndexError, AttributeError) as e:
+                print(f"Note: Unable to access widget: {str(e)}")
+            except Exception as e:
+                print(f"Error handling widget: {str(e)}")
             index_outputs.append(index_output)
             print()
 
@@ -654,6 +837,7 @@ def get_output_thredds_location(url):
 def handle_calc_indices(arg):
     """From the selected downscaled outputs, determine their location on THREDDS,
     and compute the selected indices."""
+
     for var in downscaled_output_selected.keys():
         for downscaled_output_checkbox in downscaled_output_selected[var]:
             downscaled_output_thredds = get_output_thredds_location(

--- a/on-demand_downscaling/on_demand_downscaling.ipynb
+++ b/on-demand_downscaling/on_demand_downscaling.ipynb
@@ -10,7 +10,9 @@
     "\n",
     "#### If you are ready to proceed, run the cells in <b>steps I, IV, V, VI and VII</b> below in sequence. The other steps are optional.\n",
     "\n",
-    "#### If you have run this notebook before and would like to erase any previous activity and files generated, restart the notebook by selecting <b>\"Kernel -> Restart Kernel\" from the top left menu</b>."
+    "#### If you have run this notebook before and would like to erase any previous activity and files generated, restart the notebook by selecting <b>\"Kernel -> Restart Kernel\" from the top left menu</b>.\n",
+    "\n",
+    "### *Please note that all output files will be removed from PCIC servers after a period of **two days**. We encourage you to download any data you may need within this timeframe.* "
    ]
   },
   {
@@ -90,7 +92,7 @@
     "\n",
     "#### Once the inputs are initialized, you can click the `Run Downscaling` button to start the downscaling process. Please note that only one input variable can be processed at a time. You must click the button again after adjusting your inputs to start processes for other variables.\n",
     "\n",
-    "#### Additionally, you may find a message that says `ERROR:root:Could not read status document.` or `ERROR:root:Could not parse XML response.` below the last progress bar while the processes are running. As long as you can see that the progress bars are at 20% (they stay there until the output file is being finalized at 95%), and they complete at around the approximate duration, you can safely ignore those messages."
+    "#### Additionally, you may find a message that says `ERROR:root:Could not read status document.` or `ERROR:root:Could not parse XML response.` below the last progress bar while the processes are running. As long as you can see that the progress bars filling, you can safely ignore those messages."
    ]
   },
   {

--- a/on-demand_downscaling/on_demand_downscaling.ipynb
+++ b/on-demand_downscaling/on_demand_downscaling.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "#### Once the inputs are initialized, you can click the `Run Downscaling` button to start the downscaling process. Please note that only one input variable can be processed at a time. You must click the button again after adjusting your inputs to start processes for other variables.\n",
     "\n",
-    "#### Additionally, you may find a message that says `ERROR:root:Could not read status document.` or `ERROR:root:Could not parse XML response.` below the last progress bar while the processes are running. As long as you can see that the progress bars filling, you can safely ignore those messages."
+    "#### Additionally, you may find a message that says `ERROR:root:Could not read status document.` or `ERROR:root:Could not parse XML response.` below the last progress bar while the processes are running. As long as you can see that the progress bars are steadily moving, you can safely ignore those message."
    ]
   },
   {


### PR DESCRIPTION
### Changes:
- **Chickadee Cancel Integration:**
The cancel button now sends a request to a new Chickadee WPS endpoint that terminates running downscaling processes.
- **Cooldown Mechanism to Prevent Race Conditions:**
After canceling, the "Run Downscale" button is disabled and greyed out for 45 seconds. This allows time for the cancel request to be processed and the queue to update, preventing a race condition where a new request could bypass the queue.

- **Conditional Cancel Button Display:**
The cancel button is hidden for:
    - Queued processes (since they haven't started yet)
    - Finch (climate indices) processes, as Finch does not support canceling via an API endpoint.

- **Improved Error Logging:**
User-friendly error messages instead of stack traces.

- **Documentation Update:**
Added a note that output files are deleted after **2 days** from PCIC servers.

- **Output Filename Cleanup:**
Removed the term _“on-demand”_ from all generated output file names.


resolves #4 